### PR TITLE
Initialize Python project with returns and pydantic

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = dalapy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+      - name: Run tests
+        run: pytest --cov=dalapy --cov-report=xml --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # dalapy
-Data layer in python
+
+Small data-layer helpers built on the [returns](https://github.com/dry-python/returns)
+library and [Pydantic v2](https://docs.pydantic.dev/).  It provides a generic
+repository that persists Pydantic dataclasses to disk.  Each entity dataclass
+lives in its own module making it simple to extend the domain.
+
+## Development
+
+Create a virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[test]
+```
+
+Run tests with coverage:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "dalapy"
+version = "0.1.0"
+description = "A basic project using returns and pydantic v2"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "returns",
+    "pydantic>=2",
+    "filelock",
+]
+
+[project.optional-dependencies]
+test = ["pytest", "pytest-cov"]
+
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["dalapy"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=dalapy --cov-report=term-missing"

--- a/src/dalapy/__init__.py
+++ b/src/dalapy/__init__.py
@@ -1,0 +1,20 @@
+"""Data layer helpers built on returns and Pydantic."""
+
+from .collection import Collection, collection_for
+from .env import Env
+from .product import Product
+from .repo import Repo
+from .store import GenericStore
+from .user import User
+
+__all__ = [
+    "Collection",
+    "collection_for",
+    "Env",
+    "GenericStore",
+    "Repo",
+    "User",
+    "Product",
+]
+
+__version__ = "0.1.0"

--- a/src/dalapy/collection.py
+++ b/src/dalapy/collection.py
@@ -1,0 +1,25 @@
+"""Collection metadata describing how entities are stored."""
+
+from __future__ import annotations
+
+from typing import Generic, Type, TypeVar
+
+from pydantic import ConfigDict, TypeAdapter
+from pydantic.dataclasses import dataclass as pyd_dataclass
+
+from .has_id import HasId
+
+T = TypeVar("T", bound=HasId)
+
+
+@pyd_dataclass(config=ConfigDict(extra="ignore", arbitrary_types_allowed=True))
+class Collection(Generic[T]):
+    """Associates a model class with its storage name and adapter."""
+
+    name: str
+    adapter: TypeAdapter  # TypeAdapter[T]
+
+
+def collection_for(cls: Type[T], name: str | None = None) -> Collection[T]:
+    """Attach type info + collection name to an entity class."""
+    return Collection(name=(name or f"{cls.__name__.lower()}s"), adapter=TypeAdapter(cls))

--- a/src/dalapy/env.py
+++ b/src/dalapy/env.py
@@ -1,0 +1,15 @@
+"""Configuration for storage locations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass as pyd_dataclass
+
+
+@pyd_dataclass(config=ConfigDict(extra="ignore"))
+class Env:
+    """Runtime environment defining where data is stored."""
+
+    data_path: Path
+    lock_path: Path | None = None  # enable later for multiprocess

--- a/src/dalapy/has_id.py
+++ b/src/dalapy/has_id.py
@@ -1,0 +1,9 @@
+"""Shared protocol for entities with an integer ``id`` attribute."""
+
+from typing import Protocol
+
+
+class HasId(Protocol):
+    """Protocol requiring an ``id`` attribute."""
+
+    id: int

--- a/src/dalapy/product.py
+++ b/src/dalapy/product.py
@@ -1,0 +1,14 @@
+"""Product entity model."""
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass as pyd_dataclass
+
+from .has_id import HasId
+
+
+@pyd_dataclass(config=ConfigDict(extra="ignore"))
+class Product(HasId):
+    id: int
+    sku: str
+    price: float = 0.0
+    currency: str = "SEK"

--- a/src/dalapy/repo.py
+++ b/src/dalapy/repo.py
@@ -1,0 +1,152 @@
+"""Generic repository implementing CRUD operations using ``returns``."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import os
+from pathlib import Path
+from typing import Dict, Generic, TypeVar
+
+from filelock import FileLock
+from returns.curry import curry
+from returns.io import IOResult, IOFailure, IOSuccess
+from returns.result import Result, Failure, Success
+
+from .collection import Collection
+from .env import Env
+from .has_id import HasId
+from .store import GenericStore, STORE_ADAPTER
+
+T = TypeVar("T", bound=HasId)
+V = TypeVar("V")
+
+# ========= Low-level I/O (atomic, optional lock) =========
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("wb") as f:
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def read_store(env: Env) -> IOResult[GenericStore, str]:
+    try:
+        if not env.data_path.exists():
+            return IOSuccess(GenericStore())
+        raw = env.data_path.read_bytes()
+        return IOSuccess(STORE_ADAPTER.validate_json(raw))
+    except Exception as exc:  # pragma: no cover - IO error
+        return IOFailure(f"read error: {exc}")
+
+
+def write_store(env: Env, store: GenericStore) -> IOResult[GenericStore, str]:
+    try:
+        env.data_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = STORE_ADAPTER.dump_json(store, by_alias=False)
+        if env.lock_path:
+            with FileLock(str(env.lock_path)):
+                _atomic_write_bytes(env.data_path, payload)
+        else:
+            _atomic_write_bytes(env.data_path, payload)
+        return IOSuccess(store)
+    except Exception as exc:  # pragma: no cover - IO error
+        return IOFailure(f"write error: {exc}")
+
+# ========= Generic store transforms (pure, curried) =========
+
+def _coll_view(store: GenericStore, c: Collection[T]) -> Dict[int, dict]:
+    return store.data.get(c.name, {})
+
+
+def _with_coll(store: GenericStore, c: Collection[T], newmap: Dict[int, dict]) -> GenericStore:
+    new_data = dict(store.data)
+    new_data[c.name] = newmap
+    return replace(store, data=new_data)
+
+
+@curry
+def insert(c: Collection[T], obj: T, store: GenericStore) -> Result[GenericStore, str]:
+    m = _coll_view(store, c)
+    if obj.id in m:
+        return Failure("id exists")
+    nm = dict(m)
+    nm[obj.id] = c.adapter.dump_python(obj)
+    return Success(_with_coll(store, c, nm))
+
+
+@curry
+def upsert(c: Collection[T], obj: T, store: GenericStore) -> Result[GenericStore, str]:
+    m = _coll_view(store, c)
+    nm = dict(m)
+    nm[obj.id] = c.adapter.dump_python(obj)
+    return Success(_with_coll(store, c, nm))
+
+
+@curry
+def update(c: Collection[T], obj: T, store: GenericStore) -> Result[GenericStore, str]:
+    m = _coll_view(store, c)
+    if obj.id not in m:
+        return Failure("not found")
+    nm = dict(m)
+    nm[obj.id] = c.adapter.dump_python(obj)
+    return Success(_with_coll(store, c, nm))
+
+
+@curry
+def delete(c: Collection[T], entity_id: int, store: GenericStore) -> Result[GenericStore, str]:
+    m = _coll_view(store, c)
+    if entity_id not in m:
+        return Failure("not found")
+    nm = dict(m)
+    nm.pop(entity_id)
+    return Success(_with_coll(store, c, nm))
+
+
+@curry
+def get(c: Collection[T], entity_id: int, store: GenericStore) -> Result[T, str]:
+    m = _coll_view(store, c)
+    raw = m.get(entity_id)
+    if raw is None:
+        return Failure("not found")
+    return Success(c.adapter.validate_python(raw))
+
+
+def list_all(c: Collection[T], store: GenericStore) -> Result[list[T], str]:
+    m = _coll_view(store, c)
+    return Success([c.adapter.validate_python(v) for v in m.values()])
+
+# ========= Repo that “just works” for any entity =========
+
+class Repo(Generic[T]):
+    """Repository exposing common operations for a collection."""
+
+    def __init__(self, coll: Collection[T]):
+        self.c = coll
+
+    def create(self, env: Env, obj: T) -> IOResult[T, str]:
+        return read_store(env).bind_result(insert(self.c, obj)).bind(
+            lambda store: write_store(env, store).map(lambda _: obj)
+        )
+
+    def upsert(self, env: Env, obj: T) -> IOResult[T, str]:
+        return read_store(env).bind_result(upsert(self.c, obj)).bind(
+            lambda store: write_store(env, store).map(lambda _: obj)
+        )
+
+    def update(self, env: Env, obj: T) -> IOResult[T, str]:
+        return read_store(env).bind_result(update(self.c, obj)).bind(
+            lambda store: write_store(env, store).map(lambda _: obj)
+        )
+
+    def delete(self, env: Env, entity_id: int) -> IOResult[int, str]:
+        return read_store(env).bind_result(delete(self.c, entity_id)).bind(
+            lambda store: write_store(env, store).map(lambda _: entity_id)
+        )
+
+    def get(self, env: Env, entity_id: int) -> IOResult[T, str]:
+        return read_store(env).bind_result(get(self.c, entity_id))
+
+    def list(self, env: Env) -> IOResult[list[T], str]:
+        return read_store(env).bind_result(lambda s: list_all(self.c, s))

--- a/src/dalapy/store.py
+++ b/src/dalapy/store.py
@@ -1,0 +1,23 @@
+"""Generic in-memory store with versioning."""
+
+from __future__ import annotations
+
+from dataclasses import field
+from typing import Dict
+
+from pydantic import ConfigDict, TypeAdapter
+from pydantic.dataclasses import dataclass as pyd_dataclass
+
+CURRENT_STORE_VERSION = 1
+
+
+@pyd_dataclass(config=ConfigDict(extra="ignore"))
+class GenericStore:
+    """Serialized representation of stored collections."""
+
+    version: int = CURRENT_STORE_VERSION
+    # one big map: collection -> { id -> raw-dict }
+    data: Dict[str, Dict[int, dict]] = field(default_factory=dict)
+
+
+STORE_ADAPTER = TypeAdapter(GenericStore)

--- a/src/dalapy/user.py
+++ b/src/dalapy/user.py
@@ -1,0 +1,13 @@
+"""User entity model."""
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass as pyd_dataclass
+
+from .has_id import HasId
+
+
+@pyd_dataclass(config=ConfigDict(extra="ignore"))
+class User(HasId):
+    id: int
+    name: str
+    spend: float = 0.0

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,0 +1,21 @@
+from dalapy import Env, Repo, User, collection_for
+from returns.io import IOFailure, IOSuccess
+
+
+def test_repo_crud(tmp_path):
+    env = Env(data_path=tmp_path / "data.json")
+    repo = Repo(collection_for(User, "users"))
+
+    user = User(id=1, name="Alice", spend=10.0)
+    assert repo.create(env, user) == IOSuccess(user)
+
+    # Duplicate insert fails
+    assert repo.create(env, user) == IOFailure("id exists")
+
+    updated = User(id=1, name="Alice", spend=20.0)
+    assert repo.update(env, updated) == IOSuccess(updated)
+
+    assert repo.get(env, 1) == IOSuccess(updated)
+    assert repo.list(env) == IOSuccess([updated])
+    assert repo.delete(env, 1) == IOSuccess(1)
+    assert repo.get(env, 1) == IOFailure("not found")


### PR DESCRIPTION
## Summary
- separate Env, store, collection, and entity dataclasses into dedicated modules
- implement generic Repo with CRUD helpers using returns and Pydantic
- cover CRUD flows for the User entity

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb51296008324a0b9ba6b093990da