### PR TITLE
feat: separate module and example project

### DIFF
--- a/example_project/__init__.py
+++ b/example_project/__init__.py
@@ -1,0 +1,7 @@
+"""Example project models using the dalapy module."""
+
+from .product import Product
+from .user import User
+
+__all__ = ["Product", "User"]
+

--- a/example_project/product.py
+++ b/example_project/product.py
@@ -3,7 +3,7 @@
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass as pyd_dataclass
 
-from .has_id import HasId
+from dalapy.has_id import HasId
 
 
 @pyd_dataclass(config=ConfigDict(extra="ignore"))

--- a/example_project/user.py
+++ b/example_project/user.py
@@ -3,7 +3,7 @@
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass as pyd_dataclass
 
-from .has_id import HasId
+from dalapy.has_id import HasId
 
 
 @pyd_dataclass(config=ConfigDict(extra="ignore"))

--- a/src/dalapy/__init__.py
+++ b/src/dalapy/__init__.py
@@ -2,10 +2,8 @@
 
 from .collection import Collection, collection_for
 from .env import Env
-from .product import Product
 from .repo import Repo
 from .store import GenericStore
-from .user import User
 
 __all__ = [
     "Collection",
@@ -13,8 +11,6 @@ __all__ = [
     "Env",
     "GenericStore",
     "Repo",
-    "User",
-    "Product",
 ]
 
 __version__ = "0.1.0"

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+sys.path.append(str(ROOT))
+
 from dalapy import Env, Repo, collection_for
 from example_project import User
 from returns.io import IOFailure, IOSuccess

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,4 +1,5 @@
-from dalapy import Env, Repo, User, collection_for
+from dalapy import Env, Repo, collection_for
+from example_project import User
 from returns.io import IOFailure, IOSuccess
 
 


### PR DESCRIPTION
## Summary
- move entity models into example project so consuming projects supply their own
- keep dalapy module focused on generic repository helpers
- update tests to use example project's models

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cec0ec2448324b1ec21a688438490