### PR TITLE
Add YAML loaders for example project

### DIFF
--- a/example_project/__init__.py
+++ b/example_project/__init__.py
@@ -2,5 +2,13 @@
 
 from .models import User, Product
 from .repositories import Users, Products
+from .yaml_loader import load_users_from_yaml, load_products_from_yaml
 
-__all__ = ["User", "Product", "Users", "Products"]
+__all__ = [
+    "User",
+    "Product",
+    "Users",
+    "Products",
+    "load_users_from_yaml",
+    "load_products_from_yaml",
+]

--- a/example_project/yaml_loader.py
+++ b/example_project/yaml_loader.py
@@ -1,0 +1,36 @@
+"""Utility functions to load YAML data into the example project repos."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import yaml
+from returns.io import IOResult
+
+from dalapy import Env
+from .models import User, Product
+from .repositories import Users, Products
+
+
+def load_users_from_yaml(path: Path, env: Env) -> List[IOResult[User, str]]:
+    """Read a YAML file of users and insert them into the database."""
+    data = yaml.safe_load(path.read_text()) or []
+    results: List[IOResult[User, str]] = []
+    for item in data:
+        user = User(**item)
+        results.append(Users.create_flow(user)(env))
+    return results
+
+
+def load_products_from_yaml(path: Path, env: Env) -> List[IOResult[Product, str]]:
+    """Read a YAML file of products and insert them into the database."""
+    data = yaml.safe_load(path.read_text()) or []
+    results: List[IOResult[Product, str]] = []
+    for item in data:
+        product = Product(**item)
+        results.append(Products.create_flow(product)(env))
+    return results
+
+
+__all__ = ["load_users_from_yaml", "load_products_from_yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydantic>=2",
     "filelock",
     "tinydb",
+    "pyyaml",
 ]
 
 [project.optional-dependencies]

--- a/tests/data/products.yaml
+++ b/tests/data/products.yaml
@@ -1,0 +1,8 @@
+- id: 1
+  sku: ABC
+  price: 100.0
+  currency: SEK
+- id: 2
+  sku: DEF
+  price: 200.0
+  currency: SEK

--- a/tests/data/users.yaml
+++ b/tests/data/users.yaml
@@ -1,0 +1,8 @@
+- id: 1
+  name: Alice
+  spend: 10.0
+  email: alice@example.com
+- id: 2
+  name: Bob
+  spend: 5.0
+  email: bob@example.com

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+sys.path.append(str(ROOT))
+
+from dalapy import Env, shutdown_env
+from example_project import (
+    User,
+    Product,
+    Users,
+    Products,
+    load_users_from_yaml,
+    load_products_from_yaml,
+)
+from returns.io import IOFailure, IOSuccess
+
+
+def test_yaml_loading(tmp_path):
+    env = Env(db_path=tmp_path / "data.json")
+    data_dir = Path(__file__).parent / "data"
+
+    users_yaml = data_dir / "users.yaml"
+    products_yaml = data_dir / "products.yaml"
+
+    user_objs = [User(**d) for d in yaml.safe_load(users_yaml.read_text())]
+    product_objs = [Product(**d) for d in yaml.safe_load(products_yaml.read_text())]
+
+    res_users = load_users_from_yaml(users_yaml, env)
+    res_products = load_products_from_yaml(products_yaml, env)
+
+    assert res_users == [IOSuccess(u) for u in user_objs]
+    assert res_products == [IOSuccess(p) for p in product_objs]
+
+    assert Users.list_flow()(env) == IOSuccess(user_objs)
+    assert Products.list_flow()(env) == IOSuccess(product_objs)
+
+    res_users_fail = load_users_from_yaml(users_yaml, env)
+    res_products_fail = load_products_from_yaml(products_yaml, env)
+
+    assert all(r == IOFailure("id_exists") for r in res_users_fail)
+    assert all(r == IOFailure("id_exists") for r in res_products_fail)
+
+    assert isinstance(shutdown_env()(env), IOSuccess)


### PR DESCRIPTION
## Summary
- add helper to load Users and Products from YAML files into TinyDB
- export new loader utilities from example project
- add tests with YAML fixtures verifying proper inserts and duplicate failures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f4c1140808324a3ab39d0e3d7e39a