### PR TITLE
Add YAML loaders for system product bundles

### DIFF
--- a/example_project/__init__.py
+++ b/example_project/__init__.py
@@ -1,6 +1,23 @@
 """Example project using dalapy's models."""
 
-from .models import User, Product
-from .repositories import Users, Products
+from .models import User, Product, System
+from .repositories import Users, Products, Systems
+from .data_api import DataAPI
+from .yaml_loader import (
+    load_users_from_yaml,
+    load_products_from_yaml,
+    load_system_from_yaml,
+)
 
-__all__ = ["User", "Product", "Users", "Products"]
+__all__ = [
+    "User",
+    "Product",
+    "System",
+    "Users",
+    "Products",
+    "Systems",
+    "DataAPI",
+    "load_users_from_yaml",
+    "load_products_from_yaml",
+    "load_system_from_yaml",
+]

--- a/example_project/data_api.py
+++ b/example_project/data_api.py
@@ -1,0 +1,107 @@
+"""Central data API combining CRUD and complex queries."""
+
+from __future__ import annotations
+
+from typing import List, Set, Tuple
+
+from returns.io import IOResult, IOSuccess, IOFailure
+
+from dalapy import Env
+from .models import User, Product, System
+from .repositories import Users, Products, Systems
+
+
+class DataAPI:
+    """High level data API ensuring consistent access to the DB."""
+
+    def __init__(self, env: Env):
+        self.env = env
+
+    # ---- Users ---------------------------------------------------------
+    def create_user(self, user: User) -> IOResult[User, str]:
+        return Users.create_flow(user)(self.env)
+
+    def list_users(self) -> IOResult[List[User], str]:
+        return Users.list_flow()(self.env)
+
+    def get_user(self, user_id: int) -> IOResult[User, str]:
+        return Users.get_flow(user_id)(self.env)
+
+    def get_user_by_name(self, name: str) -> IOResult[User, str]:
+        return Users.get_by_unique_flow("name", name)(self.env)
+
+    # ---- Products ------------------------------------------------------
+    def create_product(self, product: Product) -> IOResult[Product, str]:
+        return Products.create_flow(product)(self.env)
+
+    def list_products(self) -> IOResult[List[Product], str]:
+        return Products.list_flow()(self.env)
+
+    def get_product(self, product_id: int) -> IOResult[Product, str]:
+        return Products.get_flow(product_id)(self.env)
+
+    def get_product_by_sku(self, sku: str) -> IOResult[Product, str]:
+        return Products.get_by_unique_flow("sku", sku)(self.env)
+
+    def list_product_versions(self) -> IOResult[Set[str], str]:
+        res = Products.list_flow()(self.env)
+        if isinstance(res, IOFailure):
+            return res
+        products = res.unwrap()._inner_value
+        return IOSuccess({p.version for p in products if p.version})
+
+    # ---- Systems -------------------------------------------------------
+    def create_system(self, system: System) -> IOResult[System, str]:
+        for pid in system.product_ids:
+            exists_res = Products.exists_by_flow("id", pid)(self.env)
+            if isinstance(exists_res, IOFailure) or not exists_res.unwrap()._inner_value:
+                return IOFailure("missing_product")
+        return Systems.create_flow(system)(self.env)
+
+    def list_systems(self) -> IOResult[List[System], str]:
+        return Systems.list_flow()(self.env)
+
+    def get_system(self, system_id: int) -> IOResult[System, str]:
+        return Systems.get_flow(system_id)(self.env)
+
+    def get_system_by_name(self, name: str) -> IOResult[System, str]:
+        return Systems.get_by_flow("name", name, nocase=True)(self.env)
+
+    def list_system_names(self) -> IOResult[List[str], str]:
+        res = self.list_systems()
+        if isinstance(res, IOFailure):
+            return res
+        systems = res.unwrap()._inner_value
+        return IOSuccess([s.name for s in systems])
+
+    def get_products_for_system(self, system_name: str) -> IOResult[List[Product], str]:
+        sys_res = self.get_system_by_name(system_name)
+        if isinstance(sys_res, IOFailure):
+            return sys_res
+        system = sys_res.unwrap()._inner_value
+        products: List[Product] = []
+        for pid in system.product_ids:
+            p_res = self.get_product(pid)
+            if isinstance(p_res, IOFailure):
+                return p_res
+            products.append(p_res.unwrap()._inner_value)
+        return IOSuccess(products)
+
+    def list_product_skus_prices_for_system(self, system_name: str) -> IOResult[List[Tuple[str, float]], str]:
+        prods_res = self.get_products_for_system(system_name)
+        if isinstance(prods_res, IOFailure):
+            return prods_res
+        products = prods_res.unwrap()._inner_value
+        return IOSuccess([(p.sku, p.price) for p in products])
+
+    def get_product_in_system_by_version(self, system_name: str, version: str) -> IOResult[Product, str]:
+        prods_res = self.get_products_for_system(system_name)
+        if isinstance(prods_res, IOFailure):
+            return prods_res
+        for p in prods_res.unwrap()._inner_value:
+            if p.version == version:
+                return IOSuccess(p)
+        return IOFailure("not_found")
+
+
+__all__ = ["DataAPI"]

--- a/example_project/models.py
+++ b/example_project/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass as pyd_dataclass
@@ -22,6 +22,14 @@ class Product:
     sku: str
     price: float = 0.0
     currency: str = "SEK"
+    version: Optional[str] = None
 
 
-__all__ = ["User", "Product"]
+@pyd_dataclass(config=ConfigDict(extra="ignore"))
+class System:
+    id: int
+    name: str
+    product_ids: List[int]
+
+
+__all__ = ["User", "Product", "System"]

--- a/example_project/repositories.py
+++ b/example_project/repositories.py
@@ -6,7 +6,7 @@ from pydantic import TypeAdapter
 
 from dalapy import UniqueRule, RepoSpec, repo_factory
 
-from .models import User, Product
+from .models import User, Product, System
 
 
 USER_SPEC = RepoSpec[User](
@@ -21,12 +21,21 @@ PRODUCT_SPEC = RepoSpec[Product](
     unique=(UniqueRule("sku", nocase=False),),
 )
 
+SYSTEM_SPEC = RepoSpec[System](
+    table_name="systems",
+    adapter=TypeAdapter(System),
+    unique=(UniqueRule("name", nocase=True),),
+)
+
 Users = repo_factory(USER_SPEC)
 Products = repo_factory(PRODUCT_SPEC)
+Systems = repo_factory(SYSTEM_SPEC)
 
 __all__ = [
     "USER_SPEC",
     "PRODUCT_SPEC",
     "Users",
     "Products",
+    "SYSTEM_SPEC",
+    "Systems",
 ]

--- a/example_project/yaml_loader.py
+++ b/example_project/yaml_loader.py
@@ -1,0 +1,62 @@
+"""Utility functions to load YAML data into the example project repos."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+import yaml
+import tarfile
+import re
+from returns.io import IOResult
+
+from .data_api import DataAPI
+from .models import User, Product, System
+
+
+def load_users_from_yaml(path: Path, api: DataAPI) -> List[IOResult[User, str]]:
+    """Read a YAML file of users and insert them into the database."""
+    data = yaml.safe_load(path.read_text()) or []
+    results: List[IOResult[User, str]] = []
+    for item in data:
+        user = User(**item)
+        results.append(api.create_user(user))
+    return results
+
+
+def load_products_from_yaml(path: Path, api: DataAPI) -> List[IOResult[Product, str]]:
+    """Read a YAML file of products and insert them into the database."""
+    data = yaml.safe_load(path.read_text()) or []
+    results: List[IOResult[Product, str]] = []
+    for item in data:
+        product = Product(**item)
+        results.append(api.create_product(product))
+    return results
+
+
+def load_system_from_yaml(
+    path: Path, api: DataAPI
+) -> Tuple[List[IOResult[Product, str]], IOResult[System, str]]:
+    """Read a system YAML referencing product tarballs and insert them."""
+    data = yaml.safe_load(path.read_text()) or {}
+    product_results: List[IOResult[Product, str]] = []
+    product_ids: List[int] = []
+    for ref in data.get("products", []):
+        p_path = path.parent / ref
+        m = re.search(r"-(?P<version>[\d\.]+)\.tar\.gz$", p_path.name)
+        version = m.group("version") if m else ""
+        with tarfile.open(p_path, "r:gz") as tar:
+            member = tar.getmember("product.yml")
+            file = tar.extractfile(member)
+            assert file is not None
+            pdata = yaml.safe_load(file.read().decode()) or {}
+        pdata["version"] = version
+        product = Product(**pdata)
+        product_results.append(api.create_product(product))
+        product_ids.append(product.id)
+    system = System(id=data["id"], name=data["name"], product_ids=product_ids)
+    system_result = api.create_system(system)
+    return product_results, system_result
+
+
+__all__ = ["load_users_from_yaml", "load_products_from_yaml", "load_system_from_yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydantic>=2",
     "filelock",
     "tinydb",
+    "pyyaml",
 ]
 
 [project.optional-dependencies]

--- a/tests/data/products.yaml
+++ b/tests/data/products.yaml
@@ -1,0 +1,8 @@
+- id: 1
+  sku: ABC
+  price: 100.0
+  currency: SEK
+- id: 2
+  sku: DEF
+  price: 200.0
+  currency: SEK

--- a/tests/data/system.yml
+++ b/tests/data/system.yml
@@ -1,0 +1,5 @@
+id: 1
+name: DemoSystem
+products:
+  - widget-1.0.tar.gz
+  - gadget-2.0.tar.gz

--- a/tests/data/users.yaml
+++ b/tests/data/users.yaml
@@ -1,0 +1,8 @@
+- id: 1
+  name: Alice
+  spend: 10.0
+  email: alice@example.com
+- id: 2
+  name: Bob
+  spend: 5.0
+  email: bob@example.com

--- a/tests/test_system_loader.py
+++ b/tests/test_system_loader.py
@@ -64,8 +64,7 @@ def test_system_loading(tmp_path):
 
     # query products belonging to a system and list their sku and price
     skus_prices = api.list_product_skus_prices_for_system("DemoSystem")
-    assert isinstance(skus_prices, IOSuccess)
-    assert set(skus_prices.unwrap()._inner_value) == {("WID", 50.0), ("GAD", 75.0)}
+    assert skus_prices.map(set) == IOSuccess({("WID", 50.0), ("GAD", 75.0)})
 
     assert api.get_product_in_system_by_version("DemoSystem", "1.0") == IOSuccess(product1)
     assert api.get_product_in_system_by_version("DemoSystem", "2.0") == IOSuccess(product2)

--- a/tests/test_system_loader.py
+++ b/tests/test_system_loader.py
@@ -1,0 +1,77 @@
+import sys
+from pathlib import Path
+import tarfile
+import io
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+sys.path.append(str(ROOT))
+
+from dalapy import Env, shutdown_env
+from example_project import (
+    Product,
+    System,
+    DataAPI,
+    load_system_from_yaml,
+)
+from returns.io import IOFailure, IOSuccess
+
+
+def _make_bundle(path: Path, data: dict) -> None:
+    """Create a tar.gz containing a single product.yml with given data."""
+    content = yaml.safe_dump(data).encode("utf-8")
+    info = tarfile.TarInfo("product.yml")
+    info.size = len(content)
+    with tarfile.open(path, "w:gz") as tar:
+        tar.addfile(info, io.BytesIO(content))
+
+
+def test_system_loading(tmp_path):
+    env = Env(db_path=tmp_path / "data.json")
+    api = DataAPI(env)
+
+    # prepare product bundles and system.yml in a temp directory
+    data_dir = Path(__file__).parent / "data"
+    system_yaml = tmp_path / "system.yml"
+    system_yaml.write_text((data_dir / "system.yml").read_text())
+
+    _make_bundle(
+        tmp_path / "widget-1.0.tar.gz",
+        {"id": 1, "sku": "WID", "price": 50.0, "currency": "SEK"},
+    )
+    _make_bundle(
+        tmp_path / "gadget-2.0.tar.gz",
+        {"id": 2, "sku": "GAD", "price": 75.0, "currency": "SEK"},
+    )
+
+    product1 = Product(id=1, sku="WID", price=50.0, currency="SEK", version="1.0")
+    product2 = Product(id=2, sku="GAD", price=75.0, currency="SEK", version="2.0")
+    system_obj = System(id=1, name="DemoSystem", product_ids=[1, 2])
+
+    prod_res, sys_res = load_system_from_yaml(system_yaml, api)
+    assert prod_res == [IOSuccess(product1), IOSuccess(product2)]
+    assert sys_res == IOSuccess(system_obj)
+
+    assert api.list_products() == IOSuccess([product1, product2])
+    assert api.list_systems() == IOSuccess([system_obj])
+
+    # query which systems are present
+    assert api.list_system_names() == IOSuccess(["DemoSystem"])
+
+    # query product versions stored
+    assert api.list_product_versions() == IOSuccess({"1.0", "2.0"})
+
+    # query products belonging to a system and list their sku and price
+    skus_prices = api.list_product_skus_prices_for_system("DemoSystem")
+    assert isinstance(skus_prices, IOSuccess)
+    assert set(skus_prices.unwrap()._inner_value) == {("WID", 50.0), ("GAD", 75.0)}
+
+    assert api.get_product_in_system_by_version("DemoSystem", "1.0") == IOSuccess(product1)
+    assert api.get_product_in_system_by_version("DemoSystem", "2.0") == IOSuccess(product2)
+
+    prod_res_fail, sys_res_fail = load_system_from_yaml(system_yaml, api)
+    assert all(r == IOFailure("id_exists") for r in prod_res_fail)
+    assert sys_res_fail == IOFailure("id_exists")
+
+    assert isinstance(shutdown_env()(env), IOSuccess)

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+sys.path.append(str(ROOT))
+
+from dalapy import Env, shutdown_env
+from example_project import (
+    User,
+    Product,
+    DataAPI,
+    load_users_from_yaml,
+    load_products_from_yaml,
+)
+from returns.io import IOFailure, IOSuccess
+
+
+def test_yaml_loading(tmp_path):
+    env = Env(db_path=tmp_path / "data.json")
+    api = DataAPI(env)
+    data_dir = Path(__file__).parent / "data"
+
+    users_yaml = data_dir / "users.yaml"
+    products_yaml = data_dir / "products.yaml"
+
+    user_objs = [User(**d) for d in yaml.safe_load(users_yaml.read_text())]
+    product_objs = [Product(**d) for d in yaml.safe_load(products_yaml.read_text())]
+
+    res_users = load_users_from_yaml(users_yaml, api)
+    res_products = load_products_from_yaml(products_yaml, api)
+
+    assert res_users == [IOSuccess(u) for u in user_objs]
+    assert res_products == [IOSuccess(p) for p in product_objs]
+
+    assert api.list_users() == IOSuccess(user_objs)
+    assert api.list_products() == IOSuccess(product_objs)
+
+    # query for a specific user and product
+    assert api.get_user_by_name("Alice") == IOSuccess(user_objs[0])
+    assert api.get_product_by_sku("ABC") == IOSuccess(product_objs[0])
+
+    res_users_fail = load_users_from_yaml(users_yaml, api)
+    res_products_fail = load_products_from_yaml(products_yaml, api)
+
+    assert all(r == IOFailure("id_exists") for r in res_users_fail)
+    assert all(r == IOFailure("id_exists") for r in res_products_fail)
+
+    assert isinstance(shutdown_env()(env), IOSuccess)


### PR DESCRIPTION
## Summary
- introduce System model and repository and add version field to Product
- add loader that reads system.yml, extracts product.yml from referenced .tar.gz bundles, and stores products and system with ID links
- test loading of system data and duplicate failures with tarball fixtures
- generate product tarball fixtures dynamically during tests to avoid binary files in the repo
- expand tests to query stored systems, product versions, and specific user/product records
- add DataAPI facade to centralize CRUD operations and complex queries while ensuring product references exist on writes
- route YAML loaders and tests through the DataAPI for consistent database access

## Testing
- `pip install -e .[test]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4c1140808324a3ab39d0e3d7e39a