### PR TITLE
Add product groups and config loader

### DIFF
--- a/example_project/__init__.py
+++ b/example_project/__init__.py
@@ -1,23 +1,27 @@
 """Example project using dalapy's models."""
 
-from .models import User, Product, System
-from .repositories import Users, Products, Systems
+from .models import User, Product, System, ProductGroup
+from .repositories import Users, Products, Systems, ProductGroups
 from .data_api import DataAPI
 from .yaml_loader import (
     load_users_from_yaml,
     load_products_from_yaml,
     load_system_from_yaml,
 )
+from .config_loader import load_config_from_yaml
 
 __all__ = [
     "User",
     "Product",
     "System",
+    "ProductGroup",
     "Users",
     "Products",
     "Systems",
+    "ProductGroups",
     "DataAPI",
     "load_users_from_yaml",
     "load_products_from_yaml",
     "load_system_from_yaml",
+    "load_config_from_yaml",
 ]

--- a/example_project/config_loader.py
+++ b/example_project/config_loader.py
@@ -1,0 +1,50 @@
+"""Loader for mutable configuration stored in YAML."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+from returns.io import IOResult
+
+from .data_api import DataAPI
+from .models import ProductGroup
+
+
+def load_config_from_yaml(path: Path, api: DataAPI) -> Dict[str, List[IOResult[Any, str]]]:
+    """Load configuration data and apply it to the repositories.
+
+    Returns a mapping of section name to list of IOResult objects produced
+    when applying the configuration.
+    """
+    data = yaml.safe_load(path.read_text()) or {}
+    results: Dict[str, List[IOResult[Any, str]]] = {}
+
+    # Product groups are standalone entries
+    pg_results: List[IOResult[ProductGroup, str]] = []
+    for item in data.get("product_groups", []):
+        group = ProductGroup(**item)
+        pg_results.append(api.create_product_group(group))
+    if pg_results:
+        results["product_groups"] = pg_results
+
+    # Augment existing objects with extra fields
+    mapping = {
+        "products": api.update_product,
+        "users": api.update_user,
+        "systems": api.update_system,
+    }
+    for key, updater in mapping.items():
+        res_list: List[IOResult[Any, str]] = []
+        for item in data.get(key, []):
+            obj_id = item.get("id")
+            extra = {k: v for k, v in item.items() if k != "id"}
+            res_list.append(updater(obj_id, **extra))
+        if res_list:
+            results[key] = res_list
+
+    return results
+
+
+__all__ = ["load_config_from_yaml"]

--- a/example_project/data_api.py
+++ b/example_project/data_api.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from typing import List, Set, Tuple
 
+from dataclasses import replace
 from returns.io import IOResult, IOSuccess, IOFailure
 
 from dalapy import Env
-from .models import User, Product, System
-from .repositories import Users, Products, Systems
+from .models import User, Product, System, ProductGroup
+from .repositories import Users, Products, Systems, ProductGroups
 
 
 class DataAPI:
@@ -30,6 +31,13 @@ class DataAPI:
     def get_user_by_name(self, name: str) -> IOResult[User, str]:
         return Users.get_by_unique_flow("name", name)(self.env)
 
+    def update_user(self, user_id: int, **fields) -> IOResult[User, str]:
+        def _update(user: User) -> IOResult[User, str]:
+            updated = replace(user, **fields)
+            return Users.update_flow(updated)(self.env)
+
+        return self.get_user(user_id).bind(_update)
+
     # ---- Products ------------------------------------------------------
     def create_product(self, product: Product) -> IOResult[Product, str]:
         return Products.create_flow(product)(self.env)
@@ -47,6 +55,33 @@ class DataAPI:
         return Products.list_flow()(self.env).map(
             lambda products: {p.version for p in products if p.version}
         )
+
+    def update_product(self, product_id: int, **fields) -> IOResult[Product, str]:
+        def _update(product: Product) -> IOResult[Product, str]:
+            updated = replace(product, **fields)
+            return Products.update_flow(updated)(self.env)
+
+        return self.get_product(product_id).bind(_update)
+
+    # ---- Product Groups -------------------------------------------------
+    def create_product_group(self, group: ProductGroup) -> IOResult[ProductGroup, str]:
+        return ProductGroups.create_flow(group)(self.env)
+
+    def list_product_groups(self) -> IOResult[List[ProductGroup], str]:
+        return ProductGroups.list_flow()(self.env)
+
+    def get_product_group(self, group_id: int) -> IOResult[ProductGroup, str]:
+        return ProductGroups.get_flow(group_id)(self.env)
+
+    def get_product_group_by_tag(self, tag: str) -> IOResult[ProductGroup, str]:
+        return ProductGroups.get_by_unique_flow("tag", tag)(self.env)
+
+    def update_product_group(self, group_id: int, **fields) -> IOResult[ProductGroup, str]:
+        def _update(group: ProductGroup) -> IOResult[ProductGroup, str]:
+            updated = replace(group, **fields)
+            return ProductGroups.update_flow(updated)(self.env)
+
+        return self.get_product_group(group_id).bind(_update)
 
     # ---- Systems -------------------------------------------------------
     def create_system(self, system: System) -> IOResult[System, str]:
@@ -94,6 +129,19 @@ class DataAPI:
             return IOFailure("not_found")
 
         return self.get_products_for_system(system_name).bind(_find)
+
+    def update_system(self, system_id: int, **fields) -> IOResult[System, str]:
+        def _update(system: System) -> IOResult[System, str]:
+            updated = replace(system, **fields)
+            for pid in updated.product_ids:
+                exists_res = Products.exists_by_flow("id", pid)(self.env).bind(
+                    lambda exists: IOSuccess(True) if exists else IOFailure("missing_product")
+                )
+                if isinstance(exists_res, IOFailure):
+                    return exists_res
+            return Systems.update_flow(updated)(self.env)
+
+        return self.get_system(system_id).bind(_update)
 
 
 __all__ = ["DataAPI"]

--- a/example_project/models.py
+++ b/example_project/models.py
@@ -23,6 +23,7 @@ class Product:
     price: float = 0.0
     currency: str = "SEK"
     version: Optional[str] = None
+    tag: Optional[str] = None
 
 
 @pyd_dataclass(config=ConfigDict(extra="ignore"))
@@ -32,4 +33,11 @@ class System:
     product_ids: List[int]
 
 
-__all__ = ["User", "Product", "System"]
+@pyd_dataclass(config=ConfigDict(extra="ignore"))
+class ProductGroup:
+    id: int
+    tag: str
+    path: str
+
+
+__all__ = ["User", "Product", "System", "ProductGroup"]

--- a/example_project/repositories.py
+++ b/example_project/repositories.py
@@ -6,7 +6,7 @@ from pydantic import TypeAdapter
 
 from dalapy import UniqueRule, RepoSpec, repo_factory
 
-from .models import User, Product, System
+from .models import User, Product, System, ProductGroup
 
 
 USER_SPEC = RepoSpec[User](
@@ -27,9 +27,16 @@ SYSTEM_SPEC = RepoSpec[System](
     unique=(UniqueRule("name", nocase=True),),
 )
 
+PRODUCT_GROUP_SPEC = RepoSpec[ProductGroup](
+    table_name="product_groups",
+    adapter=TypeAdapter(ProductGroup),
+    unique=(UniqueRule("tag", nocase=False),),
+)
+
 Users = repo_factory(USER_SPEC)
 Products = repo_factory(PRODUCT_SPEC)
 Systems = repo_factory(SYSTEM_SPEC)
+ProductGroups = repo_factory(PRODUCT_GROUP_SPEC)
 
 __all__ = [
     "USER_SPEC",
@@ -38,4 +45,6 @@ __all__ = [
     "Products",
     "SYSTEM_SPEC",
     "Systems",
+    "PRODUCT_GROUP_SPEC",
+    "ProductGroups",
 ]

--- a/tests/data/config.yml
+++ b/tests/data/config.yml
@@ -1,0 +1,13 @@
+product_groups:
+  - id: 1
+    tag: widget
+    path: products/widget
+  - id: 2
+    tag: gadget
+    path: products/gadget
+
+products:
+  - id: 1
+    tag: widget
+  - id: 2
+    tag: gadget

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+from dataclasses import replace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+sys.path.append(str(ROOT))
+
+import yaml
+from dalapy import Env, shutdown_env
+from example_project import (
+    Product,
+    ProductGroup,
+    DataAPI,
+    load_products_from_yaml,
+    load_config_from_yaml,
+)
+from returns.io import IOSuccess
+
+
+def test_config_loader(tmp_path):
+    env = Env(db_path=tmp_path / "data.json")
+    api = DataAPI(env)
+    data_dir = Path(__file__).parent / "data"
+
+    products_yaml = data_dir / "products.yaml"
+    config_yaml = data_dir / "config.yml"
+
+    product_objs = [Product(**d) for d in yaml.safe_load(products_yaml.read_text())]
+    load_products_from_yaml(products_yaml, api)
+
+    pg1 = ProductGroup(id=1, tag="widget", path="products/widget")
+    pg2 = ProductGroup(id=2, tag="gadget", path="products/gadget")
+    expected_p1 = replace(product_objs[0], tag="widget")
+    expected_p2 = replace(product_objs[1], tag="gadget")
+
+    res = load_config_from_yaml(config_yaml, api)
+    assert res["product_groups"] == [IOSuccess(pg1), IOSuccess(pg2)]
+    assert res["products"] == [IOSuccess(expected_p1), IOSuccess(expected_p2)]
+
+    assert api.list_product_groups() == IOSuccess([pg1, pg2])
+    assert api.list_products() == IOSuccess([expected_p1, expected_p2])
+
+    assert isinstance(shutdown_env()(env), IOSuccess)


### PR DESCRIPTION
## Summary
- introduce `ProductGroup` model and `tag` field on `Product`
- add repositories and API support for product groups
- implement YAML config loader for augmenting objects and storing groups
- expose update methods on the API and use them when applying config data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a19a80d17c832483cbf91599f2c8a3